### PR TITLE
pc - first attempt at getting google cal info

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/GCalController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/GCalController.java
@@ -1,0 +1,86 @@
+package edu.ucsb.cs156.example.controllers;
+
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar.Events;
+import com.google.api.services.calendar.Calendar;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import edu.ucsb.cs156.example.services.GoogleTokenService;
+
+import com.google.api.client.http.javanet.NetHttpTransport;
+
+@Tag(name = "GCalController")
+@RequestMapping("/api/gcal")
+@Controller
+@Slf4j
+public class GCalController {
+
+    @Autowired
+    GoogleTokenService googleTokenService;
+
+    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final String APPLICATION_NAME = "Google Calendar API Java Quickstart";
+
+    @Operation(summary = "Get events from Google Calendar", description = "Get events from Google Calendar")
+    @GetMapping(value = "/events")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<String> getEvents(
+           @Parameter(name="sdate") @RequestParam(value = "sdate") String sdate,
+           @Parameter(name="edate") @RequestParam(value = "edate") String edate,
+           @Parameter(name="q") @RequestParam(value = "q") String q,
+           OAuth2AuthenticationToken authentication) {
+        log.info("sdate={}, edate={}, q={}", sdate, edate, q);
+        com.google.api.services.calendar.model.Events eventList;
+        String message;
+        try {
+            String principalName = authentication.getPrincipal().getName();
+            log.info("principalName={}", principalName);
+            String token = googleTokenService.getAccessToken(principalName).getTokenValue();
+            log.info("token={}", token);
+            GoogleCredential credential = new GoogleCredential().setAccessToken(token);
+            log.info("credential={}", credential);
+
+            final DateTime date1 = new DateTime(sdate + "T00:00:00");
+            final DateTime date2 = new DateTime(edate + "T23:59:59");
+
+            NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+            Calendar service = new Calendar.Builder(httpTransport, JSON_FACTORY, credential)
+                    .setApplicationName(APPLICATION_NAME).build();
+            Events events = service.events();
+            eventList = events.list("primary").setTimeZone("America/Los_Angeles").setTimeMin(date1).setTimeMax(date2)
+                    .setQ(q)
+                    .execute();
+            message = eventList.getItems().toString();
+            System.out.println("My:" + eventList.getItems());
+        } catch (Exception e) {
+
+            message = "Exception while handling OAuth2 callback (" + e.getMessage() + ")."
+                    + " Redirecting to google connection status page.";
+        }
+
+        return new ResponseEntity<>(message, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/services/GoogleTokenService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/GoogleTokenService.java
@@ -1,0 +1,24 @@
+package edu.ucsb.cs156.example.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class GoogleTokenService {
+
+    @Autowired
+    OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
+
+    public OAuth2AccessToken getAccessToken(String principalName) {
+        log.info("principalName={}", principalName);
+        OAuth2AuthorizedClient oAuth2AuthorizedClient = oAuth2AuthorizedClientService.loadAuthorizedClient("google", principalName);
+        return oAuth2AuthorizedClient.getAccessToken();
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,8 +13,7 @@ spring.jpa.open-in-view=false
 
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:${env.GOOGLE_CLIENT_ID:client_id_unset}}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:${env.GOOGLE_CLIENT_SECRET:client_secret_unset}}
-spring.security.oauth2.client.registration.google.scope=email,profile
-
+spring.security.oauth2.client.registration.google.scope=email,profile,https://www.googleapis.com/auth/calendar
 
 springdoc.swagger-ui.tryItOutEnabled=true
 


### PR DESCRIPTION
In this draft PR, we illustrate how to get Google Calendar info.

We followed this tutorial, mostly:

* <https://www.aurigait.com/blog/accessing-google-calendar-data-using-google-calendar-api/>

The exception is that the aurigait tutorial above is missing an explanation of these lines:
```java
        CustomOAuth2User customOAuth2User = (CustomOAuth2User)oAuth2User;
        String token = customOAuth2User.getToken();
```

To replace that, we set up a service to get the token value:
```
@Service
@Slf4j
public class GoogleTokenService {

    @Autowired
    OAuth2AuthorizedClientService oAuth2AuthorizedClientService;

    public OAuth2AccessToken getAccessToken(String principalName) {
        log.info("principalName={}", principalName);
        OAuth2AuthorizedClient oAuth2AuthorizedClient = oAuth2AuthorizedClientService.loadAuthorizedClient("google", principalName);
        return oAuth2AuthorizedClient.getAccessToken();
    }
}
```

And then we invoke that service this way:

```
            String principalName = authentication.getPrincipal().getName();
            log.info("principalName={}", principalName);
            String token = googleTokenService.getAccessToken(principalName).getTokenValue();
            log.info("token={}", token);
```